### PR TITLE
Modified Initialize_HiTMaP.R to make it silent (not interactive)

### DIFF
--- a/Initialize_HiTMaP.R
+++ b/Initialize_HiTMaP.R
@@ -1,21 +1,18 @@
-
-
-
-#install the git package
-install.packages("remotes")
-#library(devtools)
+install.packages("remotes") # allows HiTMaP to be installed from GitHub
+install.packages("config")  # allows HiTMaP to be run from configuration file. TODO: add to DESCRIPTION
+install.packages("enviPat") # TODO: add to DESCRIPTION (imports)
+install.packages("fftwtools") # TODO: add to DESCRIPTION
+BiocManager::install("EBImage") # TODO: add to DESCRIPTION
+BiocManager::install(c("Cardinal", "EBImage", "ChemmineR")) # TODO: add to DESCRIPTION
 library(remotes)
-install.packages("enviPat")
 Sys.setenv("R_REMOTES_NO_ERRORS_FROM_WARNINGS" = "true")
-install.packages("fftwtools")
-install.packages("")
-BiocManager::install("EBImage")
-BiocManager::install(c("Cardinal", "EBImage", "ChemmineR"))
-remotes::install_github("MASHUOA/HiTMaP",auth_token ="cf6d877f8b6ada1865987b13f9e9996c1883014a",force=T)
-3
-no
+remotes::install_github(
+  "MASHUOA/HiTMaP",
+  auth_token ="cf6d877f8b6ada1865987b13f9e9996c1883014a", # TODO: hide token
+  force=TRUE,
+  upgrade="always" # suppresses prompt
+)
+warnings()
 #Update all dependencies
-Sys.setenv("R_REMOTES_NO_ERRORS_FROM_WARNINGS" = "true")
-BiocManager::install(ask = F)
-yes
+#BiocManager::install(ask = F)
 library(HiTMaP)


### PR DESCRIPTION
Modified Initialize_HiTMaP.R to make it silent (not interactive).
Upgrade="always" suppresses the prompt so that the script can run without user intervention.
This allows the script to be included in a Docker build process, so that the resulting image already includes HiTMaP.

I also moved the other packages to the top of the script but including these in DESCRIPTION (imports) will install them automatically. 

I also don't think "updating all dependencies" is a good idea. 
Better to specify which version (or range of versions) you want in DESCRIPTION imports.
Otherwise there is a risk that a dependency will be updated with changes that break your code.